### PR TITLE
Improve queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 
 gem 'pry'
 gem 'rubocop'
+gem 'resolv-idn`

--- a/lib/ten34/providers/route53.rb
+++ b/lib/ten34/providers/route53.rb
@@ -2,6 +2,7 @@
 
 require 'aws-sdk'
 require 'retriable'
+require 'resolv-idn'
 
 require 'ten34/providers/base'
 
@@ -80,12 +81,8 @@ module Ten34
         logger.debug("Getting value for key: #{key}")
 
         Retriable.retriable(on: Aws::Route53::Errors::Throttling) do
-          resp = route53.list_resource_record_sets(
-            hosted_zone_id: hosted_zone_id,
-            start_record_name: "#{key}.#{name}.",
-            start_record_type: 'TXT',
-            max_items: 1
-          )
+          dns_obj = Resolv::DNS.new
+          resp = dns_obj.getresources "#{key}.#{name}.", Resolv::DNS::Resource::IN::TXT
 
           raise(Ten34::Errors::KeyNotFound, key) if resp.resource_record_sets.empty?
 


### PR DESCRIPTION
It is irresponsible to depend upon the Route 53 API for querying values when using it as a database. 

It is far more responsible to query the Route 53 database via DNS. 

Doing this in a browser so it requires testing before acceptance. We don't want to break anyone's production environment!